### PR TITLE
Fix bug where subtitles are sometimes rendered tiny

### DIFF
--- a/src/videojs.ass.js
+++ b/src/videojs.ass.js
@@ -120,7 +120,7 @@
 
         addTrack(options.src, { label: options.label, srclang: options.srclang, switchImmediately: true });
         renderers[cur_id] = new libjass.renderers.WebRenderer(ass, clocks[cur_id], overlay, rendererSettings);
-		renderers[cur_id].addEventListener('ready', function () {
+        renderers[cur_id].addEventListener('ready', function () {
           updateDisplayArea();
           player.on('play', function () {
             clocks[cur_id].play();

--- a/src/videojs.ass.js
+++ b/src/videojs.ass.js
@@ -43,10 +43,6 @@
 
     clocks[cur_id] = new libjass.renderers.AutoClock(getCurrentTime, 500);
 
-    player.on('play', function () {
-      clocks[cur_id].play();
-    });
-
     player.on('pause', function () {
       clocks[cur_id].pause();
     });
@@ -126,7 +122,9 @@
         renderers[cur_id] = new libjass.renderers.WebRenderer(ass, clocks[cur_id], overlay, rendererSettings);
 		renderers[cur_id].addEventListener('ready', function () {
           updateDisplayArea();
-          clocks[cur_id].play();
+          player.on('play', function () {
+            clocks[cur_id].play();
+          });
         });
       }
     );

--- a/src/videojs.ass.js
+++ b/src/videojs.ass.js
@@ -124,6 +124,10 @@
 
         addTrack(options.src, { label: options.label, srclang: options.srclang, switchImmediately: true });
         renderers[cur_id] = new libjass.renderers.WebRenderer(ass, clocks[cur_id], overlay, rendererSettings);
+		renderers[cur_id].addEventListener('ready', function () {
+          updateDisplayArea();
+          clocks[cur_id].play();
+        });
       }
     );
 
@@ -195,7 +199,10 @@
           cur_id = ++id_count;
           clocks[cur_id] = new libjass.renderers.AutoClock(getCurrentTime, 500);
           renderers[cur_id] = new libjass.renderers.WebRenderer(ass, clocks[cur_id], overlay, rendererSettings);
-          updateDisplayArea();
+          renderers[cur_id].addEventListener('ready', function () {
+            updateDisplayArea();
+            clocks[cur_id].play();
+          });
 
           if (switchImmediately) {
             clocks[cur_id].play();

--- a/src/videojs.ass.js
+++ b/src/videojs.ass.js
@@ -41,8 +41,6 @@
       return player.currentTime() - delay;
     }
 
-    clocks[cur_id] = new libjass.renderers.AutoClock(getCurrentTime, 500);
-
     player.on('play', function () {
       if (clocks[cur_id]) {
         clocks[cur_id].play();
@@ -204,12 +202,9 @@
           renderers[cur_id] = new libjass.renderers.WebRenderer(ass, clocks[cur_id], overlay, rendererSettings);
           renderers[cur_id].addEventListener('ready', function () {
             updateDisplayArea();
-            clocks[cur_id].play();
           });
 
-          if (switchImmediately) {
-            clocks[cur_id].play();
-          } else {
+          if (!switchImmediately) {
             renderers[cur_id]._removeAllSubs();
             renderers[cur_id]._preRenderedSubs.clear();
             renderers[cur_id].clock.disable();


### PR DESCRIPTION
This adds a "ready" event listener to the first renderer made and moves setting up "play" to that listener callback. Otherwise, #26 happens.